### PR TITLE
Feat: Content 목록 조회(무한 스크롤)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,13 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
+
+    //Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/beforespring/socialfeed/content/domain/ContentQueryParameter.java
+++ b/src/main/java/beforespring/socialfeed/content/domain/ContentQueryParameter.java
@@ -1,0 +1,26 @@
+package beforespring.socialfeed.content.domain;
+
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+
+/**
+ * @param hashtag 찾으려는 해시태그
+ * @param from    이 시점 이후에 생성된 content를 가져오게 됨.
+ * @param size    가져올 Content의 수
+ * @param offset  지정한 offset만큼 건너 뛰어서 값을 반환함. 이전에 offset이 필요하다는 응답이 온 경우, offset을 추가해야 같은 정보를 계속해서
+ *                불러오는 일을 방지할 수 있음. 클라이언트 사이드에서 offset을 계산해야함.
+ * @see ContentQueryResult
+ */
+public record ContentQueryParameter(
+    String hashtag,
+    LocalDateTime from,
+    int size,
+    int offset
+) {
+
+    @Builder
+    public ContentQueryParameter {
+    }
+}

--- a/src/main/java/beforespring/socialfeed/content/domain/ContentQueryRepository.java
+++ b/src/main/java/beforespring/socialfeed/content/domain/ContentQueryRepository.java
@@ -1,0 +1,27 @@
+package beforespring.socialfeed.content.domain;
+
+import java.util.List;
+
+
+public interface ContentQueryRepository {
+
+    /**
+     * <p>
+     * 무한스크롤을 염두에 둔 Content 조회 메서드.
+     * </p>
+     * <p>
+     * 서비스의 특성상, 새로운 게시물이 자주 올라올 수 있음.<br> 만약 단순 offset으로 구현한다면, 동일한 게시물이 중복으로 나타나는 일이 자주 발생할 것임.
+     * 따라서 특정 게시물을 anchor로 삼고, 그 이후의 데이터를 가져와야함. (보통 incremental하거나 시간 기반으로 생성된 PK를 바탕으로 acnchor를
+     * 설정함.)<br> 그러나, 본 PK서비스의 특성상 PK를 anchor로 사용할 수가 없음. (외부 SNS에서 가져오는 것이고, SNS 전체 데이터를 가져오는 것은
+     * 불가능함.)
+     * </p>
+     * <p>
+     * 마지막 게시물이 올라온 시각에 대한 정보를 바탕으로, 그 이후에 올라온 게시물들을 불러오게 됨.
+     * </p>
+     *
+     * @param queryParameter ContentQueryParameter 참조.
+     * @return list of contents (최대 size: queryParameter.size + 1)
+     * @see ContentQueryParameter
+     */
+    List<Content> findByHashtag(ContentQueryParameter queryParameter);
+}

--- a/src/main/java/beforespring/socialfeed/content/domain/ContentQueryResult.java
+++ b/src/main/java/beforespring/socialfeed/content/domain/ContentQueryResult.java
@@ -1,0 +1,27 @@
+package beforespring.socialfeed.content.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * Content QueryRepository의 결과물을 래핑할 목적으로 만들어진 클래스.
+ * @param lastContentCreatedAt 무한스크롤을 위해 사용되는 기준점. (이전 쿼리 결과의 게시물 게시 시점)
+ * @param contents             쿼리 결과
+ * @param size                 쿼리 결과 수량
+ * @param offsetRequiredNext   이전 쿼리 마지막 Content의 createdAt 과 동일한 다른 게시물이 여럿 존재하는 상황. 만약 true인 경우,
+ *                             offset을 계산해서 쿼리해야함.
+ * @param hasNext              불러오지 않은 컨텐츠가 더 있는지 여부
+ * @see ContentQueryParameter
+ */
+public record ContentQueryResult<T>(
+    LocalDateTime lastContentCreatedAt,
+    List<T> contents,
+    int size,
+    boolean offsetRequiredNext,
+    boolean hasNext
+) {
+    @Builder
+    public ContentQueryResult {
+    }
+}

--- a/src/main/java/beforespring/socialfeed/content/domain/HashtagContent.java
+++ b/src/main/java/beforespring/socialfeed/content/domain/HashtagContent.java
@@ -1,5 +1,6 @@
 package beforespring.socialfeed.content.domain;
 
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
@@ -26,12 +27,17 @@ import lombok.NoArgsConstructor;
     name = "hashtag",
     indexes = {
         @Index(
-            name = "idx__hashtag__hashtag",
-            columnList = "hashtag"
+            name = "idx__hashtag__hashtag__created_at",  // 무한스크롤에 사용되는 인덱스
+            columnList = "hashtag, created_at"
         ),
         @Index(
-            name = "idx__hashtag__content_id",
+            name = "idx__hashtag__content_id",  // 외래키 제약조건을 제거하는 대신 사용한 join용 인덱스
             columnList = "content_id"
+        ),
+        @Index(
+            name = "idx__hashtag__created_at",  // n시간 이내 가장 많이 사용된 해시태그를 찾기 위한 인덱스
+            columnList = "created_at"
+
         )
     }
 )
@@ -50,12 +56,14 @@ public class HashtagContent {
     @JoinColumn(name = "content_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Content content;
 
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
     @Builder
-    protected HashtagContent(Long id, String hashtag, Content content) {
+    protected HashtagContent(Long id, String hashtag, Content content, LocalDateTime createdAt) {
         this.id = id;
         this.hashtag = hashtag;
         this.content = content;
+        this.createdAt = createdAt;
     }
-
-
 }

--- a/src/main/java/beforespring/socialfeed/content/infra/ContentQueryRepositoryImpl.java
+++ b/src/main/java/beforespring/socialfeed/content/infra/ContentQueryRepositoryImpl.java
@@ -1,0 +1,73 @@
+package beforespring.socialfeed.content.infra;
+
+import static beforespring.socialfeed.content.domain.QContent.content1;
+import static beforespring.socialfeed.content.domain.QHashtagContent.hashtagContent;
+
+import beforespring.socialfeed.content.domain.Content;
+import beforespring.socialfeed.content.domain.ContentQueryParameter;
+import beforespring.socialfeed.content.domain.ContentQueryRepository;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ContentQueryRepositoryImpl implements ContentQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ContentQueryRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<Content> findByHashtag(ContentQueryParameter queryParameter) {
+        BooleanExpression condition =
+            queryParameter.from() == null ? null
+                : createdBefore(queryParameter.from());
+
+        return findByHashtagQuery(
+            queryParameter.hashtag(),
+            queryParameter.size(),
+            queryParameter.offset(),
+            condition);
+    }
+
+    private static BooleanExpression createdBefore(LocalDateTime from) {
+        return hashtagContent.createdAt.before(from);
+    }
+
+    private static BooleanExpression hashtagMatches(String hashtag) {
+        return hashtagContent.hashtag.eq(hashtag);
+    }
+
+    /**
+     * @param hashtag 불러올 hashtag
+     * @param size 불러올 content 숫자. 더 불러올 content가 존재하는지 판단하기위해 +1만큼 더 불러옴.
+     * @param offset 쿼리 시작지점에서 offset만큼 건너 뛰고 조회함.
+     * @param condition 커스텀 가능한 where 조건문. And 조건으로 작동함.
+     * @return List of Content
+     */
+    private List<Content> findByHashtagQuery(
+        String hashtag,
+        int size,
+        int offset,
+        Predicate condition
+    ) {
+        return queryFactory
+                   .select(content1)  // Content 가져와야함.
+                   .from(hashtagContent)  // 드라이빙 테이블
+                   .join(content1)
+                   .on(hashtagContent.content.eq(content1))  // content
+                   .where(hashtagMatches(hashtag)
+                              .and(condition))  // condition은 null일 수 있음.
+                   .orderBy(
+                       hashtagContent.createdAt.desc())  // hashtagContent 최신순
+                   .offset(offset)  // 해당 시간에 올라온 게시물이 여럿 존재하는 경우 사용됨.
+                   .limit(size + 1)  // 요청된 size보다 하나 더 불러옴.
+                   .fetch();
+    }
+}

--- a/src/test/java/beforespring/Fixture.java
+++ b/src/test/java/beforespring/Fixture.java
@@ -1,0 +1,44 @@
+package beforespring;
+
+import beforespring.socialfeed.content.domain.Content;
+import beforespring.socialfeed.content.domain.ContentSourceType;
+import java.time.LocalDateTime;
+import java.util.Random;
+import net.bytebuddy.utility.RandomString;
+
+public class Fixture {
+
+    static final ContentSourceType[] contentSourceTypes = ContentSourceType.values();
+
+    static public final Random random = new Random();
+
+    static public String randString() {
+        return RandomString.make();
+    }
+
+    static public ContentSourceType randomSourceType() {
+        return contentSourceTypes[random.nextInt(0, contentSourceTypes.length)];
+    }
+
+    /**
+     * @return 1 ~ 1,000,000 사이의 Long
+     */
+    static public Long randomPositiveLong() {
+        return random.nextLong(0, 1000000);
+    }
+
+    static public Content.ContentBuilder aContent() {
+        LocalDateTime createdAt = LocalDateTime.now().minusSeconds(randomPositiveLong());
+        return Content.builder()
+                   .contentSourceId(randString())
+                   .contentSourceType(randomSourceType())
+                   .title(randString())
+                   .content(randString() + randString() + randString() + randString())
+                   .likeCount(randomPositiveLong())
+                   .shareCount(randomPositiveLong())
+                   .viewCount(randomPositiveLong())
+                   .createdAt(createdAt)
+                   .updatedAt(createdAt);
+    }
+
+}

--- a/src/test/java/beforespring/socialfeed/content/domain/ContentQueryRepositoryImplTest.java
+++ b/src/test/java/beforespring/socialfeed/content/domain/ContentQueryRepositoryImplTest.java
@@ -1,0 +1,136 @@
+package beforespring.socialfeed.content.domain;
+
+import static beforespring.Fixture.randString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import beforespring.Fixture;
+import beforespring.socialfeed.content.infra.ContentQueryRepositoryImpl;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+// todo 테스트 케이스 보완 (한 content에 여러 hashtag가 설정된 경우 등)
+@DataJpaTest
+class ContentQueryRepositoryImplTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private ContentQueryRepositoryImpl contentQueryRepository;
+
+    List<HashtagContent> mapToHashtagContent(List<Content> contents, String hashtag) {
+        return contents.stream()
+                   .map(content -> HashtagContent.builder()
+                                       .content(content)
+                                       .createdAt(content.getCreatedAt())
+                                       .hashtag(hashtag)
+                                       .build())
+                   .toList();
+    }
+
+    /**
+     * @param hashtag     content에 반드시 포함되는 해시태그
+     * @param howManySets howManySets 만큼 현재 시각에 동시 생성된 content, 과거에 생성된 content 각각 생성.
+     */
+    private void initDummyData(String hashtag, int howManySets) {
+        LocalDateTime now = LocalDateTime.now();
+        List<Content> createdAtTheSameTime = Stream.generate(() -> Fixture.aContent()
+                                                                       .createdAt(now)
+                                                                       .updatedAt(now)
+                                                                       .build())
+                                                 .limit(howManySets)
+                                                 .toList();
+        List<Content> createdAtRandomPast = Stream.generate(() -> Fixture.aContent()
+                                                                      .build())
+                                                .limit(howManySets)
+                                                .toList();
+        createdAtTheSameTime.forEach(em::persist);
+        createdAtRandomPast.forEach(em::persist);
+        em.flush();
+
+        List<HashtagContent> createdAtTheSameTimeHC = mapToHashtagContent(createdAtTheSameTime,
+            hashtag);
+        List<HashtagContent> createdAtRandomPastHC = mapToHashtagContent(createdAtRandomPast,
+            hashtag);
+
+        createdAtTheSameTimeHC.forEach(em::persist);
+        createdAtRandomPastHC.forEach(em::persist);
+        em.flush();
+    }
+
+    @BeforeEach
+    void init() {
+        contentQueryRepository = new ContentQueryRepositoryImpl(em);
+    }
+
+    @Test
+    void findByHashtag() {
+        // given
+        String givenHashtag = randString();
+        int givenContentSets = 10;  // 2배만큼 생성됨. (10개 현재 시점에 동시 생성, 10개 랜덤한 과거에 생성)
+        initDummyData(givenHashtag, givenContentSets);  // givenHashtag로 생성함.
+        initDummyData(randString(),
+            givenContentSets);  // 무작위 생성된 hashtag로 생성함. (hashtag 일치하는 content만 가져오는 것인지 검증하기 위해 생성함)
+
+        int givenQuerySize = givenContentSets;  // 1개 더 가져오는지 테스트하기 위해서 사용됨.
+
+        // offset 설정되지 않은 파라미터
+        ContentQueryParameter noOffsetParam = ContentQueryParameter.builder()
+                                                  .size(givenQuerySize)
+                                                  .from(null)
+                                                  .offset(0)
+                                                  .hashtag(givenHashtag)
+                                                  .build();
+        // offset이 설정된 파라미터
+        ContentQueryParameter halfOffsetParam = ContentQueryParameter.builder()
+                                                    .size(givenQuerySize)
+                                                    .from(null)
+                                                    .offset(givenQuerySize)
+                                                    .hashtag(givenHashtag)
+                                                    .build();
+        // offset이 설정되지 않았고, 생성된 총 content보다 더 많은 양의 정보를 불러오는 파라미터
+        ContentQueryParameter noOffsetLargeSizeParam = ContentQueryParameter.builder()
+                                                           .size(givenQuerySize * 4)
+                                                           .from(null)
+                                                           .offset(0)
+                                                           .hashtag(givenHashtag)
+                                                           .build();
+
+        // when
+        List<Content> noOffsetResult = contentQueryRepository.findByHashtag(noOffsetParam);
+        List<Content> halfOffsetResult = contentQueryRepository.findByHashtag(halfOffsetParam);
+        List<Content> noOffsetLargeSizeResult = contentQueryRepository.findByHashtag(
+            noOffsetLargeSizeParam);
+
+        // then
+        assertThat(noOffsetResult)
+            .describedAs("시간 내림차순 정렬.")
+            .isSortedAccordingTo(Comparator.comparing(Content::getCreatedAt).reversed())
+            .describedAs("요청 개수보다 1개 더 찾아와야함.")
+            .hasSize(givenQuerySize + 1);
+
+        assertThat(halfOffsetResult)
+            .describedAs("시간 내림차순 정렬.")
+            .isSortedAccordingTo(Comparator.comparing(Content::getCreatedAt).reversed())
+            .describedAs("offset이 1/2만큼 설정되었기 때문에 더 가져올 것이 없음.")
+            .hasSize(givenQuerySize);
+
+        assertThat(noOffsetResult.get(noOffsetResult.size() - 1).getId())
+            .describedAs(
+                "offset이 쿼리 사이즈와 동일하게 설정되었기 때문에, halfOffsetResult의 첫번째 element는 noOffsetResult의 첫번째 element와 같음.")
+            .isEqualTo(halfOffsetResult.get(0).getId());
+
+        assertThat(noOffsetLargeSizeResult)
+            .describedAs("시간 내림차순 정렬.")
+            .isSortedAccordingTo(Comparator.comparing(Content::getCreatedAt).reversed())
+            .describedAs(
+                "givenHashtag에 해당하는 정보보다 더 많은 size로 요청했을 때, 총 size가 일치하지 않는 경우 다른 해시태그를 불러왔거나 불러와야할 일부 검색결과를 불러오지 않았다는 의미임.")
+            .hasSize(givenContentSets * 2);
+    }
+}


### PR DESCRIPTION
- querydsl 라이브러리를 사용하여 구현했습니다.
- 적절한 무한스크롤 구현과 쿼리 성능을 위해 정규화를 일부 희생하여 `HashtagContent`에 `createdAt` 필드(컬럼)을 추가했습니다.
- 테스트용 Fixture를 추가했습니다. 
- 목록 조회는 스프링에서 제공하는 `Slice`와 유사한 방식으로 작동하지만, 조회시 파라미터가 조금 더 필요합니다.

Ref: #34 