### PR TITLE
Feat: 게시물 목록 쿼리 결과 ContentQueryResult<Content> 타입으로 매핑

### DIFF
--- a/src/main/java/beforespring/socialfeed/content/domain/ContentQueryRepository.java
+++ b/src/main/java/beforespring/socialfeed/content/domain/ContentQueryRepository.java
@@ -1,8 +1,5 @@
 package beforespring.socialfeed.content.domain;
 
-import java.util.List;
-
-
 public interface ContentQueryRepository {
 
     /**
@@ -20,8 +17,8 @@ public interface ContentQueryRepository {
      * </p>
      *
      * @param queryParameter ContentQueryParameter 참조.
-     * @return list of contents (최대 size: queryParameter.size + 1)
+     * @return ContentQueryResult&lt;Content&gt;
      * @see ContentQueryParameter
      */
-    List<Content> findByHashtag(ContentQueryParameter queryParameter);
+    ContentQueryResult<Content> findByHashtag(ContentQueryParameter queryParameter);
 }

--- a/src/main/java/beforespring/socialfeed/content/domain/ContentQueryResult.java
+++ b/src/main/java/beforespring/socialfeed/content/domain/ContentQueryResult.java
@@ -2,10 +2,12 @@ package beforespring.socialfeed.content.domain;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.function.Function;
 import lombok.Builder;
 
 /**
  * Content QueryRepository의 결과물을 래핑할 목적으로 만들어진 클래스.
+ *
  * @param lastContentCreatedAt 무한스크롤을 위해 사용되는 기준점. (이전 쿼리 결과의 게시물 게시 시점)
  * @param contents             쿼리 결과
  * @param size                 쿼리 결과 수량
@@ -21,7 +23,26 @@ public record ContentQueryResult<T>(
     boolean offsetRequiredNext,
     boolean hasNext
 ) {
+
     @Builder
     public ContentQueryResult {
+    }
+
+    /**
+     * contents만 다른 타입으로 매핑한 인스턴스를 생성하여 반환함.
+     * @param mappingFunction 람다 Function in: T, returns: NT
+     * @return mappingFunction에 의해 매핑된 객체
+     * @param <NT> 매핑 결과 클래스
+     */
+    public <NT> ContentQueryResult<NT> map(Function<T, NT> mappingFunction) {
+        return ContentQueryResult.<NT>builder()
+                   .lastContentCreatedAt(lastContentCreatedAt)
+                   .size(size)
+                   .offsetRequiredNext(offsetRequiredNext)
+                   .hasNext(hasNext)
+                   .contents(contents.stream()
+                                 .map(mappingFunction)
+                                 .toList())
+                   .build();
     }
 }

--- a/src/main/java/beforespring/socialfeed/content/infra/ContentQueryMapper.java
+++ b/src/main/java/beforespring/socialfeed/content/infra/ContentQueryMapper.java
@@ -1,0 +1,62 @@
+package beforespring.socialfeed.content.infra;
+
+import beforespring.socialfeed.content.domain.Content;
+import beforespring.socialfeed.content.domain.ContentQueryRepository;
+import beforespring.socialfeed.content.domain.ContentQueryResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 더 많은 컨텐츠 존재 여부, offset 설정 필요 여부를 판단하여 ContentQueryResult로 매핑하는 클래스
+ * @see ContentQueryRepository
+ * @see ContentQueryResult
+ */
+@Component
+public class ContentQueryMapper {
+    boolean hasNext(List<Content> contents, int requestedSize) {
+        return contents.size() > requestedSize;
+    }
+
+    LocalDateTime getLastCreatedAt(List<Content> contents) {
+        return contents.isEmpty() ? null
+                   : contents.get(contents.size() - 1).getCreatedAt();
+    }
+
+    boolean offsetRequiredNext(List<Content> contents, boolean hasNext) {
+        if (!hasNext) {
+            return false;
+        }
+        LocalDateTime nextContentCreationTime = getLastCreatedAt(contents);
+        LocalDateTime lastContentCreationTime = contents.get(contents.size() - 2).getCreatedAt();
+        return nextContentCreationTime.isEqual(lastContentCreationTime);
+    }
+
+    /**
+     * ContentQueryResult로 매핑하는 메서드. 더 불러올 컨텐츠가 남았는지, 다음 쿼리는 어떻게 넣어야 하는지에 대한 정보를 포함하여 반환함.
+     *
+     * @param contents      content list
+     * @param requestedSize 요청한 사이즈 (요청한 수량보다 하나 더 가져와서 hasNext 여부를 판단함.)
+     * @return ContentQueryResult
+     */
+    public ContentQueryResult<Content> mapToContentQueryResult(
+        List<Content> contents,
+        int requestedSize
+    ) {
+        boolean hasNext = hasNext(contents, requestedSize);
+        boolean offsetRequiredNext = offsetRequiredNext(contents, hasNext);
+
+        if (hasNext) {
+            contents = contents.subList(0, contents.size() - 1);
+        }
+
+        return ContentQueryResult.<Content>builder()
+                   .lastContentCreatedAt(getLastCreatedAt(contents))
+                   .size(contents.size())
+                   .hasNext(hasNext)
+                   .offsetRequiredNext(offsetRequiredNext)
+                   .contents(contents)
+                   .build();
+    }
+}

--- a/src/test/java/beforespring/socialfeed/content/domain/ContentQueryResultTest.java
+++ b/src/test/java/beforespring/socialfeed/content/domain/ContentQueryResultTest.java
@@ -1,0 +1,53 @@
+package beforespring.socialfeed.content.domain;
+
+import static beforespring.Fixture.random;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ContentQueryResultTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void mapTo(boolean bool) {
+        // given
+        ContentQueryResult<String> given =
+            ContentQueryResult.<String>builder()
+                .contents(List.of("1", "2", "3"))
+                .offsetRequiredNext(bool)
+                .hasNext(!bool)
+                .size(random.nextInt(0,1000000))
+                .lastContentCreatedAt(LocalDateTime.now())
+                .build();
+
+        // when
+        ContentQueryResult<Integer> res = given.map(Integer::parseInt);
+
+        // then
+        assertThat(
+            tuple(
+                given.offsetRequiredNext(), given.hasNext(), given.size(),
+                given.lastContentCreatedAt()
+            ))
+            .describedAs("contents를 제외한 필드가 동일한지 확인")
+            .isEqualTo(
+                tuple(
+                    res.offsetRequiredNext(), given.hasNext(), given.size(),
+                    given.lastContentCreatedAt()
+                ));
+
+        List<Integer> expected = given.contents().stream()
+                                     .map(Integer::valueOf)
+                                     .toList();
+
+        List<Integer> actual = res.contents();
+
+        assertThat(actual)
+            .describedAs("content가 변환되었는지 확인")
+            .containsExactlyElementsOf(expected);
+    }
+}

--- a/src/test/java/beforespring/socialfeed/content/infra/ContentQueryMapperTest.java
+++ b/src/test/java/beforespring/socialfeed/content/infra/ContentQueryMapperTest.java
@@ -1,0 +1,144 @@
+package beforespring.socialfeed.content.infra;
+
+import static beforespring.Fixture.aContent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import beforespring.socialfeed.content.domain.Content;
+import beforespring.socialfeed.content.domain.Content.ContentBuilder;
+import beforespring.socialfeed.content.domain.ContentQueryResult;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ContentQueryMapperTest {
+
+    ContentQueryMapper mapper = new ContentQueryMapper();
+
+    @Test
+    void mapToContentQueryResult() {
+    }
+
+    @Test
+    @DisplayName("List 크기가 요청한 것 보다 크면 hasNext true")
+    void mapFrom_has_next_true() {
+        // given
+        int givenRequestedSize = 10;
+        List<Content> contentsSortedByCreatedAtDesc = Stream.generate(() -> aContent().build())
+                                                          .limit(givenRequestedSize + 1)  // givenRequestedSize보다 1 많이 생성
+                                                          .sorted(Comparator.comparing(
+                                                              Content::getCreatedAt).reversed())
+                                                          .toList();
+
+        // when
+        ContentQueryResult<Content> result = mapper.mapToContentQueryResult(
+            contentsSortedByCreatedAtDesc, givenRequestedSize
+        );
+
+        // then
+        assertThat(result.hasNext())
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("List 크기가 요청한 것 보다 크지 않으면(작거나 같으면) hasNext true")
+    void mapFrom_has_next_false() {
+        // given
+        int givenRequestedSize = 10;
+        List<Content> contentsSortedByCreatedAtDesc = Stream.generate(() -> aContent().build())
+                                                          .limit(
+                                                              givenRequestedSize)  // givenRequestedSize와 동일
+                                                          .sorted(Comparator.comparing(
+                                                              Content::getCreatedAt).reversed())
+                                                          .toList();
+
+        // when
+        ContentQueryResult<Content> result = mapper.mapToContentQueryResult(
+            contentsSortedByCreatedAtDesc, givenRequestedSize
+        );
+
+        // then
+        assertThat(result.hasNext())
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("마지막 두 Content가 같은 시점에 생성되고, hasNext인 경우 offset required true")
+    void mapToContentListElements_offset_required_true() {
+        // given
+        int givenRequestedSize = 10;
+        LocalDateTime lastTwoElementCreatedAt = LocalDateTime.now().minusYears(1);
+        List<Content> contentsSortedByCreatedAtDesc = IntStream.range(0, givenRequestedSize + 1) // givenRequestedSize보다 1개 많이.
+                                                          .mapToObj(i -> {
+                                                              ContentBuilder builder = aContent();
+                                                              if (i >= givenRequestedSize - 1) {  // 마지막 두 Content가 같은 시점에 생성됨.
+                                                                  builder.createdAt(lastTwoElementCreatedAt);
+                                                              }
+                                                              return builder.build();
+                                                          })
+                                                          .toList();
+
+        // when
+        ContentQueryResult<Content> result = mapper.mapToContentQueryResult(
+            contentsSortedByCreatedAtDesc, givenRequestedSize
+        );
+
+        // then
+        assertThat(result.offsetRequiredNext())
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("마지막 두 Content가 같은 시점에 생성되었지만 hasNext가 false인 경우 offsetRequired false")
+    void mapToContentListElements_offset_required_true_when_has_next_is_false() {
+        // given
+        int givenRequestedSize = 10;
+        LocalDateTime lastTwoElementCreatedAt = LocalDateTime.now().minusYears(1);
+        List<Content> contentsSortedByCreatedAtDesc = IntStream.range(0, givenRequestedSize) // givenRequestedSize와 동일한 수량을 생성함.
+                                                          .mapToObj(i -> {
+                                                              ContentBuilder builder = aContent();
+                                                              if (i >= givenRequestedSize - 1) {  // 마지막 두 Content가 같은 시점에 생성됨.
+                                                                  builder.createdAt(lastTwoElementCreatedAt);
+                                                              }
+                                                              return builder.build();
+                                                          })
+                                                          .toList();
+
+        // when
+        ContentQueryResult<Content> result = mapper.mapToContentQueryResult(
+            contentsSortedByCreatedAtDesc, givenRequestedSize
+        );
+
+        // then
+        assertThat(result.hasNext())
+            .isFalse();
+        assertThat(result.offsetRequiredNext())
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("마지막 두 element가 다르면 offsetRequired false")
+    void mapToContentListElements_offset_not_required() {
+        // given
+        int givenRequestedSize = 10;
+        List<Content> contentsSortedByCreatedAtDesc = Stream.generate(() -> aContent().build())
+                                                          .limit(givenRequestedSize + 1)  // givenRequestedSize보다 1 많이 생성
+                                                          .sorted(Comparator.comparing(
+                                                              Content::getCreatedAt).reversed())
+                                                          .toList();
+
+        // when
+        ContentQueryResult<Content> result = mapper.mapToContentQueryResult(
+            contentsSortedByCreatedAtDesc, givenRequestedSize
+        );
+
+        // then
+        assertThat(result.hasNext())
+            .isTrue();
+        assertThat(result.offsetRequiredNext())
+            .isFalse();
+    }
+}


### PR DESCRIPTION
- ContentQueryResult#map 추가, 외부에서 매핑 로직을 받아 contents만 매핑하여 반환 가능하도록 구현
- List<Content>를 ContentQueryResult<Content>로 매핑하는 로직이 복잡하여 분리 구현
- 매퍼를 제대로 호출하는지 테스트 코드 작성
- 매퍼 로직에 대한 테스트 코드 작성