### PR TITLE
Refactor: remove password param of ConfirmTokenRequest

### DIFF
--- a/src/main/java/beforespring/socialfeed/member/service/MemberServiceImpl.java
+++ b/src/main/java/beforespring/socialfeed/member/service/MemberServiceImpl.java
@@ -57,7 +57,6 @@ public class MemberServiceImpl implements MemberService {
     public void joinConfirm(ConfirmTokenRequest request) {
         Member member = memberRepository.findByUsername(request.getUsername()).orElseThrow(MemberNotFoundException::new);
         Confirm confirm = confirmRepository.findByMember(member).orElseThrow(ConfirmNotFoundException::new);
-        member.verifyPassword(request.getPassword(), passwordHasher);
         confirm.verifyToken(request.getToken());
         member.joinConfirm();
     }

--- a/src/main/java/beforespring/socialfeed/member/service/dto/ConfirmTokenDto.java
+++ b/src/main/java/beforespring/socialfeed/member/service/dto/ConfirmTokenDto.java
@@ -14,13 +14,10 @@ public class ConfirmTokenDto {
         @NotEmpty
         private String username;
         @NotEmpty
-        private String password;
-        @NotEmpty
         private String token;
 
-        public ConfirmTokenRequest(String username, String password, String token) {
+        public ConfirmTokenRequest(String username, String token) {
             this.username = username;
-            this.password = password;
             this.token = token;
         }
     }

--- a/src/test/java/beforespring/socialfeed/web/api/v1/member/MemberControllerTest.java
+++ b/src/test/java/beforespring/socialfeed/web/api/v1/member/MemberControllerTest.java
@@ -1,13 +1,7 @@
 package beforespring.socialfeed.web.api.v1.member;
 
-import static beforespring.socialfeed.member.service.dto.ConfirmTokenDto.ConfirmTokenRequest;
-import static beforespring.socialfeed.member.service.dto.CreateMemberDto.CreateMemberRequest;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import beforespring.socialfeed.web.api.v1.content.ContentController;
 import beforespring.socialfeed.member.service.MemberService;
-import beforespring.socialfeed.web.api.v1.member.MemberController;
+import beforespring.socialfeed.web.api.v1.content.ContentController;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +18,11 @@ import org.springframework.security.config.annotation.web.configurers.AuthorizeH
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static beforespring.socialfeed.member.service.dto.ConfirmTokenDto.ConfirmTokenRequest;
+import static beforespring.socialfeed.member.service.dto.CreateMemberDto.CreateMemberRequest;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest
 class MemberControllerTest {
@@ -81,7 +80,7 @@ class MemberControllerTest {
 
         String requestBody = objectMapper.writeValueAsString(request);
 
-        mockMvc.perform(post("/api/member/new")
+        mockMvc.perform(post("/api/v1/member/new")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(requestBody))
             .andExpect(status().isOk())
@@ -91,11 +90,11 @@ class MemberControllerTest {
     @Test
     @DisplayName("데이터를 가지고 API가 호출되면 가입 승인 서비스가 실행되어야됩니다")
     void confirm_member_test() throws Exception {
-        ConfirmTokenRequest request = new ConfirmTokenRequest("username", "1234", "1234");
+        ConfirmTokenRequest request = new ConfirmTokenRequest("username", "1234");
 
         String requestBody = objectMapper.writeValueAsString(request);
 
-        mockMvc.perform(post("/api/member/confirm")
+        mockMvc.perform(post("/api/v1/member/confirm")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(requestBody))
             .andExpect(status().isOk())


### PR DESCRIPTION
계정과 인증코드만으로 회원 인증이 가능하기 때문에 비밀번호는 포함시키지 않는 것으로 변경함